### PR TITLE
Update MsoLanguageID.xml

### DIFF
--- a/officedocs-dev-office-pia/xml/Microsoft.Office.Core/MsoLanguageID.xml
+++ b/officedocs-dev-office-pia/xml/Microsoft.Office.Core/MsoLanguageID.xml
@@ -1543,7 +1543,7 @@
       </ReturnValue>
       <MemberValue>1122</MemberValue>
       <Docs>
-        <summary>French as spoken in the Netherlands.</summary>
+        <summary>Frisian as spoken in the Netherlands.</summary>
       </Docs>
     </Member>
     <Member MemberName="msoLanguageIDFulfulde">


### PR DESCRIPTION
The current description for LanguageID 1122 (msoLanguageIDFrisianNetherlands) is "French as spoken in the Netherlands.". Frisian is Frisian; it is not French. The description should be changed to "Frisian as spoken in the Netherlands."
Thanks.